### PR TITLE
Linear quantization for signed integers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinLogQuantization"
 uuid = "44354dd6-1ce2-4e80-a0fb-98a3a2b05088"
 authors = ["Milan <milankloewer@gmx.de>, Pablo <valdunciel.pablo@gmail.com> and contributors"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,17 @@
 name = "LinLogQuantization"
 uuid = "44354dd6-1ce2-4e80-a0fb-98a3a2b05088"
 authors = ["Milan <milankloewer@gmx.de> and contributors"]
-version = "0.3.0"
+version = "0.2.2"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
+Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "1"
-StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
 BitIntegers = "0.2, 0.3"
+StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinLogQuantization"
 uuid = "44354dd6-1ce2-4e80-a0fb-98a3a2b05088"
 authors = ["Milan <milankloewer@gmx.de> and contributors"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LinLogQuantization"
 uuid = "44354dd6-1ce2-4e80-a0fb-98a3a2b05088"
-authors = ["Milan <milankloewer@gmx.de> and contributors"]
+authors = ["Milan <milankloewer@gmx.de>, Pablo <valdunciel.pablo@gmail.com> and contributors"]
 version = "0.2.2"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.2.2"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 BitIntegers = "0.2, 0.3"
+StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,9 @@ version = "0.2.2"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
-Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 BitIntegers = "0.2, 0.3"
-StatsBase = "0.30, 0.31, 0.32, 0.33, 0.34"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -273,8 +273,18 @@ Approximate throughputs in a MacBook Pro M2, 24GB RAM are (via `@benchmark`)
 | compression      |  800 MB/s |  800 MB/s |  100 MB/s |  700 MB/s |
 | decompression    | 2000 MB/s | 2000 MB/s | 2000 MB/s | 2000 MB/s |
 
-24-bit quantization is via `UInt24`  and `Int24` from the `BitIntegers` package,
-which introduces a drastic slow-down.
+
+Note: 24-bit quantization is via `UInt24`  and `Int24` from the `BitIntegers` package, which introduces a drastic slow-down. 
+
+### Overhead of `Base.extrema`
+Compression with custom extrema is much faster because calling `Base.extrema`, which is used for the default case, is avoided. `Base.extrema` iterates over the entire array to calculate the extrema, which adds an important overhead for large arrays:
+
+| Array size | Float64 | Float32 | Float16 |
+| ------------ | --------: | --------: | --------: |
+| 10^4 | 0.048287 ms | 0.048272 ms | 0.050938 ms |
+| 10^5 | 0.485512 ms | 0.491345 ms | 0.510508 ms |
+| 10^6 | 4.863599 ms | 4.864014 ms | 5.124977 ms |
+| 10^7 | 48.206972 ms | 48.153047 ms | 50.873535 ms |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -250,27 +250,28 @@ element in the uncompressed array.
  
 ## Benchmarking
 
-Approximate throughputs are (via `@btime`)
+Approximate throughputs in a MacBook Pro M2, 24GB RAM are (via `@benchmark`)
 
-### Unsigned integers 
-| Method           | UInt8    | UInt16    | UInt24   |   UInt32 |
+### Linear quantization
+| Method           | UInt8    | Int8     | UInt16    | Int16     | UInt24   | Int24    | UInt32   | Int32    |
+| ---------------- | -------: | -------: | --------: | --------: | -------: | -------: | -------: | -------: |
+| **Default extrema** |
+| compression      | 1500 MB/s | 1500 MB/s | 1500 MB/s | 1500 MB/s |  100 MB/s |  100 MB/s | 1500 MB/s | 1500 MB/s |
+| decompression    | 16000 MB/s | 8000 MB/s | 16000 MB/s | 8000 MB/s | 8000 MB/s | 8000 MB/s | 16000 MB/s | 16000 MB/s |
+| **Custom extrema** |
+| compression      | 8000 MB/s | 8000 MB/s | 8000 MB/s | 8000 MB/s |    100 MB/s |    100 MB/s | 8000 MB/s | 8000 MB/s |
+| decompression    | 16000 MB/s | 8000 MB/s | 16000 MB/s | 8000 MB/s |    8000 MB/s |    8000 MB/s | 16000 MB/s | 16000 MB/s |
+
+
+### Logarithmic quantization
+| Method           | UInt8    | UInt16    | UInt24   | UInt32   |
 | ---------------- | -------: | --------: | -------: | -------: |
-| **Linear**       |
-| compression      | 1350 MB/s| 1350 MB/s | 50 MB/s  | 1350 MB/s|
-| decompression    | 4700 MB/s| 4700 MB/s | 4000 MB/s| 3600 MB/s| 
-| **Logarithmic**  |
-| compression      |  285 MB/s|   285 MB/s|   40 MB/s|  285 MB/s|
-| decompression    |  250 MB/s|   250 MB/s|  250 MB/s|  500 MB/s|
-
-
-### Signed integers
-
-### Unsigned integers 
-| Method           | UInt8   | UInt16     | UInt24   |    UInt32 |
-| ---------------- | -------: | --------: | -------: | -------: |
-| **Linear**       |
-| compression      | - MB/s| - MB/s | - MB/s| - MB/s|
-| decompression    | - MB/s| - MB/s | - MB/s| - MB/s| 
+| **linspace** |
+| compression      |  800 MB/s |  800 MB/s |  100 MB/s |  700 MB/s |
+| decompression    | 2000 MB/s | 2000 MB/s | 2000 MB/s | 2000 MB/s |
+| **logspace** |
+| compression      |  800 MB/s |  800 MB/s |  100 MB/s |  700 MB/s |
+| decompression    | 2000 MB/s | 2000 MB/s | 2000 MB/s | 2000 MB/s |
 
 24-bit quantization is via `UInt24`  and `Int24` from the `BitIntegers` package,
 which introduces a drastic slow-down.

--- a/src/LinLogQuantization.jl
+++ b/src/LinLogQuantization.jl
@@ -1,5 +1,7 @@
 module LinLogQuantization
 
+    const Option{T} = Union{T,Nothing}
+
     export  LinQuantArray, LogQuantArray,
     LinQuant8Array, LinQuant16Array, LinQuant24Array, LinQuant32Array,
     LogQuant8Array, LogQuant16Array, LogQuant24Array, LogQuant32Array,

--- a/src/LinLogQuantization.jl
+++ b/src/LinLogQuantization.jl
@@ -2,6 +2,8 @@ module LinLogQuantization
 
     export  LinQuantArray, LogQuantArray,
     LinQuant8Array, LinQuant16Array, LinQuant24Array, LinQuant32Array,
+    LinQuantUInt8Array, LinQuantUInt16Array, LinQuantUInt24Array, LinQuantUInt32Array,
+    LinQuantInt8Array, LinQuantInt16Array, LinQuantInt24Array, LinQuantInt32Array,
     LogQuant8Array, LogQuant16Array, LogQuant24Array, LogQuant32Array,
     minpos
 

--- a/src/LinLogQuantization.jl
+++ b/src/LinLogQuantization.jl
@@ -5,11 +5,11 @@ module LinLogQuantization
     LogQuant8Array, LogQuant16Array, LogQuant24Array, LogQuant32Array,
     minpos
 
-    # enable UInt24 support
+    # enable UInt24 and Int24 support
     import BitIntegers
     BitIntegers.@define_integers 24
 
-    export UInt24
+    export UInt24, Int24
 
     include("linquantarrays.jl")
     include("logquantarrays.jl")

--- a/src/LinLogQuantization.jl
+++ b/src/LinLogQuantization.jl
@@ -2,8 +2,6 @@ module LinLogQuantization
 
     export  LinQuantArray, LogQuantArray,
     LinQuant8Array, LinQuant16Array, LinQuant24Array, LinQuant32Array,
-    LinQuantUInt8Array, LinQuantUInt16Array, LinQuantUInt24Array, LinQuantUInt32Array,
-    LinQuantInt8Array, LinQuantInt16Array, LinQuantInt24Array, LinQuantInt32Array,
     LogQuant8Array, LogQuant16Array, LogQuant24Array, LogQuant32Array,
     minpos
 

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -1,6 +1,9 @@
+
+const Maybe{T} = Union{T,Nothing}
+
 """Struct that holds the quantised array as UInts with an additional
 field for the min, max of the original range."""
-struct LinQuantArray{T,N} <: AbstractArray{Unsigned,N}
+struct LinQuantArray{T,N} <: AbstractArray{Integer,N}
     A::Array{T,N}       # array of UInts
     min::Float64        # offset min, max
     max::Float64
@@ -10,83 +13,163 @@ Base.size(QA::LinQuantArray) = size(QA.A)
 Base.getindex(QA::LinQuantArray,i...) = getindex(QA.A,i...)
 Base.eltype(Q::LinQuantArray{T,N}) where {T,N} = T
 
-"""Quantise an array linearly into a LinQuantArray."""
-function LinQuantization(::Type{T},A::AbstractArray) where {T<:Unsigned}
+"""
+
+        LinQuantization(::Type{T}, A::AbstractArray; extrema::Tuple = extrema(A)) where {T<:Integer}
+
+Quantise an array linearly into a LinQuantArray.
+
+# Arguments
+- `T`: the type of the quantised array
+- `A`: the array to quantise
+- `extrema`: the minimum and maximum of the range, defaults to `extrema(A)`.
+
+# Returns
+- a LinQuantArray{T} with the quantised array and the minimum and maximum of the original range.
+"""
+
+function LinQuantization(
+    ::Type{T},
+    A::AbstractArray,
+    extrema::Nothing
+) where {T<:Integer}
     all(isfinite.(A)) || throw(DomainError("Linear quantization only in (-∞,∞)"))
 
-    Amin = Float64(minimum(A))              # minimum of value range
-    Amax = Float64(maximum(A))              # maximum of value range
+    # range of values in A
+    Amin, Amax  = Float64(minimum(A)), Float64(maximum(A))    
 
-    if Amin == Amax
-        Δ = 0.0                                 # set to zero for no range
-    else
-        Δ = (2^(sizeof(T)*8)-1)/(Amax-Amin)     # inverse spacing
-    end
+    # minimum and maximum representable value of type T
+    Tmin, Tmax = Float64(typemin(T)), Float64(typemax(T))
+
+    # inverse spacing, set to zero for no range
+    α⁻¹ = Amin == Amax ? zero(Float64) : (Tmax-Tmin)/(Amax-Amin)
 
     Q = similar(A,T)                        # preallocate
 
-    # map minimum to 0x0, maximum to 0xff...ff
+    # map minimum to typemin(T), maximum to typemax(t)
     @inbounds for i in eachindex(Q)
-        Q[i] = round((A[i]-Amin)*Δ)
+        Q[i] = round((A[i]-Amin)*α⁻¹ + Tmin)
     end
 
     return LinQuantArray{T,ndims(Q)}(Q,Amin,Amax)
 end
 
-# define 8, 16, 24 and 32 bit
+function LinQuantization(
+    ::Type{T},
+    A::AbstractArray,
+    extrema::Tuple = extrema(A),
+) where {T<:Integer}
+    all(isfinite.(A)) || throw(DomainError("Linear quantization only in (-∞,∞)"))
+
+    # minimum-maximum range of values
+    Amin, Amax = Float64.(extrema)    
+    
+    # minimum and maximum representable value of type T
+    Tmin, Tmax = Float64(typemin(T)), Float64(typemax(T))
+
+    # inverse spacing, set to zero for no range
+    α⁻¹ = Amin == Amax ? zero(Float64) : (Tmax-Tmin)/(Amax-Amin)
+    
+    # preallocate
+    Q = similar(A, T)                        
+
+    # map minimum to typemin(T), maximum to typemax(t)
+    # clamp to [Amin,Amax] removing out-of-range values
+    @inbounds for i in eachindex(Q)
+        Q[i] = round(T, (clamp(A[i], Amin, Amax) - Amin)*α⁻¹ + Tmin)
+    end
+
+    return LinQuantArray{T,ndims(Q)}(Q,Amin,Amax)
+end
+
+# keep compatibility with previous version
 LinQuant8Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt8,A)
 LinQuant16Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt16,A)
 LinQuant24Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt24,A)
 LinQuant32Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt32,A)
 
-"""De-quantise a LinQuantArray into floats."""
-function Base.Array{T}(n::Integer,Q::LinQuantArray) where {T<:AbstractFloat}
-    Qmin = Q.min                # min as Float64
-    Qmax = Q.max                # max as Float64
-    Δ = (Qmax-Qmin)/(2^n-1)     # linear spacing
+# define for unsigned integers of  8, 16, 24 and 32 bit 
+LinQuantUInt8Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt8,A,e)
+LinQuantUInt16Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt16,A,e)
+LinQuantUInt24Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt24,A,e)
+LinQuantUInt32Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt32,A,e)
 
-    A = similar(Q,T)
+# define for signed integers of  8, 16, 24 and 32 bit
+LinQuantInt8Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int8,A,e)
+LinQuantInt16Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int16,A,e)
+LinQuantInt24Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int24,A,e)
+LinQuantInt32Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int32,A,e)
+
+
+"""De-quantise a LinQuantArray into floats."""
+function Base.Array{U}(n::Integer, Q::LinQuantArray) where {U<:AbstractFloat}
+    Qmin = Q.min                     # min of original Array as Float64
+    Qmax = Q.max                     # max of original Array as Float64
+    Tmin = Float64(typemin(Q.A[1]))  # min representable in type as Float64
+    Tmax = Float64(typemax(Q.A[1]))  # max representable in type as Float64
+    α = (Qmax-Qmin)/(Tmax-Tmin)          # linear spacing
+
+    A = similar(Q,U)
 
     @inbounds for i in eachindex(A)
-        # convert Q[i]::UInt to Float64 via *
+        # convert Q[i]::Integer to Float64 via *
         # then to T through =
-        A[i] = Qmin + Q[i]*Δ
+        A[i] = Qmin + (Q[i] - Tmin)*α
     end
 
     return A
 end
 
-# define default conversions for 8, 16, 24 and 32 bit
+# define default conversions for unsigned 8, 16, 24 and 32 bit
 Base.Array{T}(Q::LinQuantArray{UInt8,N}) where {T,N} = Array{T}(8,Q)
 Base.Array{T}(Q::LinQuantArray{UInt16,N}) where {T,N} = Array{T}(16,Q)
 Base.Array{T}(Q::LinQuantArray{UInt24,N}) where {T,N} = Array{T}(24,Q)
 Base.Array{T}(Q::LinQuantArray{UInt32,N}) where {T,N} = Array{T}(32,Q)
 
-Base.Array(Q::LinQuantArray{UInt8,N}) where N = Array{Float32}(8,Q)
-Base.Array(Q::LinQuantArray{UInt16,N}) where N = Array{Float32}(16,Q)
-Base.Array(Q::LinQuantArray{UInt24,N}) where N = Array{Float32}(24,Q)
-Base.Array(Q::LinQuantArray{UInt32,N}) where N = Array{Float64}(32,Q)
+# define default conversions for signed 8, 16, 24 and 32 bit
+Base.Array(Q::LinQuantArray{Int8,N}) where N = Array{Float32}(8,Q)
+Base.Array(Q::LinQuantArray{Int16,N}) where N = Array{Float32}(16,Q)
+Base.Array(Q::LinQuantArray{Int24,N}) where N = Array{Float32}(24,Q)
+Base.Array(Q::LinQuantArray{Int32,N}) where N = Array{Float64}(32,Q)
 
 # one quantization per layer
 """Linear quantization independently for every element along dimension
 dim in array A. Returns a Vector{LinQuantArray}."""
-function LinQuantArray(::Type{TUInt},A::AbstractArray{T,N},dim::Int) where {TUInt,T,N}
+function LinQuantArray(
+    ::Type{TInteger},
+    A::AbstractArray{T,N},
+    dim::Int,
+    extrema::Maybe{Tuple} = nothing
+) where {TInteger,T,N}
     @assert dim <= N   "Can't quantize a $N-dimensional array in dim=$dim"
     n = size(A)[dim]
     L = Vector{LinQuantArray}(undef,n)
     t = [if j == dim 1 else Colon() end for j in 1:N]
     for i in 1:n
         t[dim] = i
-        L[i] = LinQuantization(TUInt,A[t...])    
+        L[i] = LinQuantization(TInteger,A[t...], extrema)    
     end
     return L
 end
 
-# for 8,16,24 and 32 bit
+# keep compatibility with previous version
 LinQuant8Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt8,A,dim)
 LinQuant16Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt16,A,dim)
 LinQuant24Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt24,A,dim)
 LinQuant32Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt32,A,dim)
+
+# for unsigned integers  8,16,24 and 32 bit
+LinQuantUInt8Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt8,A,dim,e)
+LinQuantUInt16Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt16,A,dim,e)
+LinQuantUInt24Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt24,A,dim,e)
+LinQuantUInt32Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt32,A,dim,e)
+
+# for signed integers of 8,16,24 and 32 bit
+LinQuantInt8Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int8,A,dim,e)
+LinQuantInt16Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int16,A,dim,e)
+LinQuantInt24Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int24,A,dim,e)
+LinQuantInt32Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int32,A,dim,e)
+
 
 """Undo the linear quantisation independently along one dimension, and returns
 an array whereby the dimension always comes last. Hence, might be permuted compared

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -1,8 +1,10 @@
-
 const Option{T} = Union{T,Nothing}
 
-"""Struct that holds the quantised array as UInts with an additional
-field for the min, max of the original range."""
+"""
+    LinQuantArray{T,N}
+Struct that holds the quantised array as UInts with an additional
+field for the min, max of the original range.
+"""
 struct LinQuantArray{T,N} <: AbstractArray{Integer,N}
     A::Array{T,N}       # array of UInts
     min::Float64        # offset min, max
@@ -15,7 +17,7 @@ Base.eltype(Q::LinQuantArray{T,N}) where {T,N} = T
 
 """
 
-        LinQuantization(::Type{T}, A::AbstractArray; extrema::Tuple = extrema(A)) where {T<:Integer}
+    LinQuantization(::Type{T}, A::AbstractArray; extrema::Tuple = extrema(A)) where {T<:Integer}
 
 Quantise an array linearly into a LinQuantArray.
 
@@ -67,14 +69,25 @@ function LinQuantArray{U}(A::AbstractArray{T,N}; extrema::Option{Tuple}=nothing)
     LinQuantization(U,A; extrema=extrema)
 end
 
-# keep compatibility: shortcuts for unsigned integers of  8, 16, 24 and 32 bit 
+# keep compatibility: shortcuts for unsigned integers of 8, 16, 24 and 32 bit
 LinQuant8Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt8,A)
 LinQuant16Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt16,A)
 LinQuant24Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt24,A)
 LinQuant32Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt32,A)
 
 
-"""De-quantise a LinQuantArray into floats."""
+"""
+    Array{U}(Q::LinQuantArray) where {U<:AbstractFloat}
+
+De-quantise a LinQuantArray into floats.
+
+# Arguments
+- `U`: the type of the de-quantised array
+- `Q`: the LinQuantArray to de-quantise
+
+# Returns
+- an array of type U with the de-quantised values.
+"""
 function Base.Array{U}(Q::LinQuantArray) where {U<:AbstractFloat}
     Qmin = Q.min                     # min of original Array as Float64
     Qmax = Q.max                     # max of original Array as Float64
@@ -94,21 +107,34 @@ function Base.Array{U}(Q::LinQuantArray) where {U<:AbstractFloat}
     return A
 end
 
-# define default conversions for unsigned 8, 16, 24 and 32 bit
+# default conversions for unsigned 8, 16, 24 and 32 bit
 Base.Array(Q::LinQuantArray{UInt8,N}) where {N} = Array{Float32}(Q)
 Base.Array(Q::LinQuantArray{UInt16,N}) where {N} = Array{Float32}(Q)
 Base.Array(Q::LinQuantArray{UInt24,N}) where {N} = Array{Float32}(Q)
 Base.Array(Q::LinQuantArray{UInt32,N}) where {N} = Array{Float64}(Q)
 
-# define default conversions for signed 8, 16, 24 and 32 bit
+# default conversions for signed 8, 16, 24 and 32 bit
 Base.Array(Q::LinQuantArray{Int8,N}) where N = Array{Float32}(Q)
 Base.Array(Q::LinQuantArray{Int16,N}) where N = Array{Float32}(Q)
 Base.Array(Q::LinQuantArray{Int24,N}) where N = Array{Float32}(Q)
 Base.Array(Q::LinQuantArray{Int32,N}) where N = Array{Float64}(Q)
 
-# one quantization per layer
-"""Linear quantization independently for every element along dimension
-dim in array A. Returns a Vector{LinQuantArray}."""
+
+"""
+    LinQuantArray(TInteger, A, dim; extrema=nothing)
+
+Linear quantization independently for every element along dimension
+dim in array A.
+
+# Arguments
+- `TInteger`: the type of the quantised array
+- `A`: the array to quantise
+- `dim`: the dimension along which to quantise
+- `extrema`: the minimum and maximum of the range, defaults to `nothing`.
+
+# Returns
+- a Vector{LinQuantArray} with the quantised array and the minimum and maximum of the original range.
+"""
 function LinQuantArray(
     ::Type{TInteger},
     A::AbstractArray{T,N},
@@ -126,11 +152,15 @@ function LinQuantArray(
     return L
 end
 
-function LinQuantArray{U}(A::AbstractArray{T,N},dim::Int; extrema::Option{Tuple}=nothing) where {U<:Integer,T,N} 
+function LinQuantArray{U}(
+    A::AbstractArray{T,N},
+    dim::Int; 
+    extrema::Option{Tuple}=nothing
+) where {U<:Integer,T,N} 
     LinQuantArray(U,A,dim;extrema=extrema)
 end
 
-# for unsigned integers  8,16,24 and 32 bit
+# keep compatibility: shortcuts for unsigned integers of 8, 16, 24 and 32 bit
 LinQuant8Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt8,A,dim)
 LinQuant16Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt16,A,dim)
 LinQuant24Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt24,A,dim)
@@ -138,18 +168,21 @@ LinQuant32Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt
 
 
 
-"""Undo the linear quantisation independently along one dimension, and returns
+"""
+    Array{U}(L::Vector{LinQuantArray}) where {U<:AbstractFloat}
+
+Undo the linear quantisation independently along one dimension, and returns
 an array whereby the dimension always comes last. Hence, might be permuted compared
-to the uncompressed array."""
-function Base.Array{T}(L::Vector{LinQuantArray}) where T
+to the uncompressed array.
+"""
+function Base.Array{U}(L::Vector{LinQuantArray}) where {U<:AbstractFloat}
     N = ndims(L[1])
     n = length(L)
     s = size(L[1])
     t = axes(L[1])
-    A = Array{T,N+1}(undef,s...,length(L))
+    A = Array{U,N+1}(undef,s...,length(L))
     for i in 1:n
-        A[t...,i] = Array{T}(L[i])
+        A[t...,i] = Array{U}(L[i])
     end
     return A
 end
-

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -126,7 +126,7 @@ function LinQuantArray(
     return L
 end
 
-function LinQuantArray{U}(A::AbstractArray{T,N},dim::Int,extrema::Option{Tuple}=nothing) where {U<:Integer,T,N} 
+function LinQuantArray{U}(A::AbstractArray{T,N},dim::Int; extrema::Option{Tuple}=nothing) where {U<:Integer,T,N} 
     LinQuantArray(U,A,dim;extrema=extrema)
 end
 

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -121,9 +121,13 @@ function LinQuantArray(
     t = [if j == dim 1 else Colon() end for j in 1:N]
     for i in 1:n
         t[dim] = i
-        L[i] = LinQuantization(TInteger,A[t...],extrema)    
+        L[i] = LinQuantization(TInteger,A[t...]; extrema=extrema)    
     end
     return L
+end
+
+function LinQuantArray{U}(A::AbstractArray{T,N},dim::Int,extrema::Option{Tuple}=nothing) where {U<:Integer,T,N} 
+    LinQuantArray(U,A,dim;extrema=extrema)
 end
 
 # for unsigned integers  8,16,24 and 32 bit
@@ -132,7 +136,7 @@ LinQuant16Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt
 LinQuant24Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt24,A,dim)
 LinQuant32Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt32,A,dim)
 
-LinQuantArray{T}(A::AbstractArray{T,N},dim::Int,ext::Option{Tuple}=nothing) where {T,N} = LinQuantArray(T,A,dim, ext)
+
 
 """Undo the linear quantisation independently along one dimension, and returns
 an array whereby the dimension always comes last. Hence, might be permuted compared

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -1,5 +1,5 @@
 
-const Maybe{T} = Union{T,Nothing}
+const Option{T} = Union{T,Nothing}
 
 """Struct that holds the quantised array as UInts with an additional
 field for the min, max of the original range."""
@@ -89,16 +89,16 @@ LinQuant24Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt24,A)
 LinQuant32Array(A::AbstractArray{T,N}) where {T,N} = LinQuantization(UInt32,A)
 
 # define for unsigned integers of  8, 16, 24 and 32 bit 
-LinQuantUInt8Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt8,A,e)
-LinQuantUInt16Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt16,A,e)
-LinQuantUInt24Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt24,A,e)
-LinQuantUInt32Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(UInt32,A,e)
+LinQuantUInt8Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(UInt8,A,e)
+LinQuantUInt16Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(UInt16,A,e)
+LinQuantUInt24Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(UInt24,A,e)
+LinQuantUInt32Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(UInt32,A,e)
 
 # define for signed integers of  8, 16, 24 and 32 bit
-LinQuantInt8Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int8,A,e)
-LinQuantInt16Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int16,A,e)
-LinQuantInt24Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int24,A,e)
-LinQuantInt32Array(A::AbstractArray{T,N}, e::Maybe{Tuple}) where {T,N} = LinQuantization(Int32,A,e)
+LinQuantInt8Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(Int8,A,e)
+LinQuantInt16Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(Int16,A,e)
+LinQuantInt24Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(Int24,A,e)
+LinQuantInt32Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQuantization(Int32,A,e)
 
 
 """De-quantise a LinQuantArray into floats."""
@@ -139,7 +139,7 @@ function LinQuantArray(
     ::Type{TInteger},
     A::AbstractArray{T,N},
     dim::Int,
-    extrema::Maybe{Tuple} = nothing
+    extrema::Option{Tuple} = nothing
 ) where {TInteger,T,N}
     @assert dim <= N   "Can't quantize a $N-dimensional array in dim=$dim"
     n = size(A)[dim]
@@ -159,16 +159,16 @@ LinQuant24Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt
 LinQuant32Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LinQuantArray(UInt32,A,dim)
 
 # for unsigned integers  8,16,24 and 32 bit
-LinQuantUInt8Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt8,A,dim,e)
-LinQuantUInt16Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt16,A,dim,e)
-LinQuantUInt24Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt24,A,dim,e)
-LinQuantUInt32Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(UInt32,A,dim,e)
+LinQuantUInt8Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(UInt8,A,dim,e)
+LinQuantUInt16Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(UInt16,A,dim,e)
+LinQuantUInt24Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(UInt24,A,dim,e)
+LinQuantUInt32Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(UInt32,A,dim,e)
 
 # for signed integers of 8,16,24 and 32 bit
-LinQuantInt8Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int8,A,dim,e)
-LinQuantInt16Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int16,A,dim,e)
-LinQuantInt24Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int24,A,dim,e)
-LinQuantInt32Array(A::AbstractArray{T,N},dim::Int,e::Maybe{Tuple}) where {T,N} = LinQuantArray(Int32,A,dim,e)
+LinQuantInt8Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(Int8,A,dim,e)
+LinQuantInt16Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(Int16,A,dim,e)
+LinQuantInt24Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(Int24,A,dim,e)
+LinQuantInt32Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(Int32,A,dim,e)
 
 
 """Undo the linear quantisation independently along one dimension, and returns

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -1,5 +1,3 @@
-const Option{T} = Union{T,Nothing}
-
 """
     LinQuantArray{T,N}
 Struct that holds the quantised array as UInts with an additional

--- a/src/linquantarrays.jl
+++ b/src/linquantarrays.jl
@@ -105,8 +105,8 @@ LinQuantInt32Array(A::AbstractArray{T,N}, e::Option{Tuple}) where {T,N} = LinQua
 function Base.Array{U}(n::Integer, Q::LinQuantArray) where {U<:AbstractFloat}
     Qmin = Q.min                     # min of original Array as Float64
     Qmax = Q.max                     # max of original Array as Float64
-    Tmin = Float64(typemin(Q.A[1]))  # min representable in type as Float64
-    Tmax = Float64(typemax(Q.A[1]))  # max representable in type as Float64
+    Tmin = Float64(typemin(eltype(Q)))  # min representable in type as Float64
+    Tmax = Float64(typemax(eltype(Q)))  # max representable in type as Float64
     Δ = (Qmax-Qmin)/(Tmax-Tmin)          # linear spacing
 
     A = similar(Q,U)

--- a/src/logquantarrays.jl
+++ b/src/logquantarrays.jl
@@ -57,7 +57,7 @@ function LogQuantization(
     Q = similar(A,T)
 
     @inbounds for i in eachindex(A)
-        # store 0 as 0x00...
+        # store 0 as 0x00...
         # store positive numbers via convert to logpacking as 0x1-0xff..
         Q[i] = iszero(A[i]) ? zero(T) : convert(T,round(c + Δ⁻¹*log(Float64(A[i]))))+one(T)
     end

--- a/src/logquantarrays.jl
+++ b/src/logquantarrays.jl
@@ -1,5 +1,8 @@
-"""Struct that holds the quantised array as UInts with an additional
-field for the min, max of the original range."""
+"""
+    LogQuantArray{T,N}
+Struct that holds the quantised array as UInts with an additional
+field for the min, max of the original range.
+"""
 struct LogQuantArray{T,N} <: AbstractArray{Unsigned,N}
     A::Array{T,N}       # array of UInts
     min::Float64        # min of value range
@@ -10,7 +13,12 @@ Base.size(QA::LogQuantArray) = size(QA.A)
 Base.getindex(QA::LogQuantArray,i...) = getindex(QA.A,i...)
 Base.eltype(Q::LogQuantArray{T,N}) where {T,N} = T
 
-"""Return minimum, ignoring negatives and zeroes."""
+"""
+    minpos(A::AbstractArray{T}) where T
+
+# Returns
+- the minimum positive value of the array, ignoring negatives and zeroes.
+"""
 function minpos(A::AbstractArray{T}) where T
     o = zero(T)
     mi = foldl((x,y) -> y > o ? min(x,y) : x, A; init=typemax(T))
@@ -18,8 +26,19 @@ function minpos(A::AbstractArray{T}) where T
     return mi
 end
 
-"""Quantize elements of an array logarithmically into UInts with
-either round to nearest in linear or Logarithmic space."""
+"""
+    LogQuantization(::Type{T}, A::AbstractArray, round_nearest_in::Symbol=:linspace) where {T<:Unsigned}
+
+Quantize elements of an array logarithmically into UInts with either round to nearest in linear or logarithmic space.
+
+# Arguments
+- `T`: the type of the quantised array
+- `A`: the array to quantise
+- `round_nearest_in`: either `:linspace` or `:logspace`
+
+# Returns
+- a LogQuantArray{T} with the quantised array and the minimum and maximum of the original range.
+"""
 function LogQuantization(   
     ::Type{T},
     A::AbstractArray,
@@ -71,7 +90,18 @@ LogQuant16Array(A::AbstractArray{T,N},rn::Symbol=:linspace) where {T,N} = LogQua
 LogQuant24Array(A::AbstractArray{T,N},rn::Symbol=:linspace) where {T,N} = LogQuantization(UInt24,A,rn)
 LogQuant32Array(A::AbstractArray{T,N},rn::Symbol=:linspace) where {T,N} = LogQuantization(UInt32,A,rn)
 
-"""De-quantise a LogQuantArray into floats."""
+"""
+    Array{T}(n::Integer,Q::LogQuantArray) where {T<:AbstractFloat}
+
+De-quantise a LogQuantArray into floats.
+
+# Arguments
+- `n`: the number of bits in the quantised array
+- `Q`: the LogQuantArray to de-quantise
+
+# Returns
+- an array of type T with the de-quantised values.
+"""
 function Base.Array{T}(n::Integer,Q::LogQuantArray) where {T<:AbstractFloat}
     Qlogmin = Q.min                 # log(min::Float64)
     Qlogmax = Q.max                 # log(max::Float64)
@@ -101,9 +131,21 @@ Base.Array(Q::LogQuantArray{UInt24,N}) where N = Array{Float32}(24,Q)
 Base.Array(Q::LogQuantArray{UInt32,N}) where N = Array{Float64}(32,Q)
 
 # one quantization per layer
-"""Logarithmic quantization independently for every element along dimension
-dim in array A. Returns a Vector{LogQuantArray}."""
-function LogQuantArray(::Type{TUInt},A::AbstractArray{T,N},dim::Int) where {TUInt,T,N}
+"""
+    LogQuantArray(::Type{TUInt},A::AbstractArray{T,N},dim::Int) where {TUInt,T,N}
+
+Logarithmic quantization independently for every element along dimension
+dim in array A.
+
+# Arguments
+- `TUInt`: the type of the quantised array
+- `A`: the array to quantise
+- `dim`: the dimension along which to quantise
+
+# Returns
+- a Vector{LogQuantArray} with the quantised array and the minimum and maximum of the original range.
+"""
+function LogQuantArray(::Type{TUInt},A::AbstractArray{T,N},dim::Int) where {TUInt<:Unsigned,T,N}
     @assert dim <= N   "Can't quantize a $N-dimensional array in dim=$dim"
     n = size(A)[dim]
     L = Vector{LogQuantArray}(undef,n)
@@ -115,15 +157,23 @@ function LogQuantArray(::Type{TUInt},A::AbstractArray{T,N},dim::Int) where {TUIn
     return L
 end
 
+function LogQuantArray{U}(A::AbstractArray{T,N},dim::Int) where {U<:Unsigned,T,N}
+    LogQuantArray(U,A,dim)
+end
+
 # for 8,16,24 and 32 bit
 LogQuant8Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LogQuantArray(UInt8,A,dim)
 LogQuant16Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LogQuantArray(UInt16,A,dim)
 LogQuant24Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LogQuantArray(UInt24,A,dim)
 LogQuant32Array(A::AbstractArray{T,N},dim::Int) where {T,N} = LogQuantArray(UInt32,A,dim)
 
-"""Undo the logarithmic quantisation independently along one dimension, and returns
+"""
+    Array{T}(L::Vector{LogQuantArray}) where {T}
+
+Undo the logarithmic quantisation independently along one dimension, and returns
 an array whereby the dimension always comes last. Hence, might be permuted compared
-to the uncompressed array."""
+to the uncompressed array.
+"""
 function Base.Array{T}(L::Vector{LogQuantArray}) where T
     N = ndims(L[1])
     n = length(L)

--- a/test/benchmarking.jl
+++ b/test/benchmarking.jl
@@ -1,0 +1,161 @@
+# To run the benchmarks, you need to install BenchmarkTools and Printf  
+using LinLogQuantization
+using BenchmarkTools
+using Printf
+
+"""
+Calculate rounded throughput in MB/s
+"""
+function calculate_throughput(size_mb::Float64, time_ms::Float64)
+    # Round time to nearest multiple of 5ms
+    rounded_time = round(time_ms/5) * 5
+    # Calculate throughput and round to nearest 100 MB/s
+    throughput = size_mb/(rounded_time/1000)
+    return round(throughput/100) * 100
+end
+
+"""
+Benchmark linear quantization for a given array size
+"""
+function benchmark_linear_quantization(n::Int)
+    A = rand(Float64, n)
+    size_mb = sizeof(A)/1000^2
+    
+    println("\nBenchmarking Linear Quantization (Array size: $(size_mb) MB)...")
+    
+    # Store results
+    results = Dict{String, Dict{String, Dict{String, Int}}}()
+    
+    # Test integers ordered by bit size
+    for with_extrema in ["default", "custom"]
+        results[with_extrema] = Dict{String, Dict{String, Int}}()
+
+        for I in [UInt8, Int8, UInt16, Int16, UInt24, Int24, UInt32, Int32]
+            type_name = string(I)
+            results[with_extrema][type_name] = Dict{String, Int}()
+
+            # Compression
+            if with_extrema == "custom"
+                ext = (0.2, 0.8)  # Example extrema values
+                b_comp = @benchmark LinQuantArray{$I}($A; extrema=$ext)
+                compressed = LinQuantArray{I}(A; extrema=ext)
+            else
+                b_comp = @benchmark LinQuantArray{$I}($A)
+                compressed = LinQuantArray{I}(A)
+            end
+            
+            time_comp = mean(b_comp.times) / 1e6  # Convert ns to ms and compute mean
+            results[with_extrema][type_name]["compression"] = Int(calculate_throughput(size_mb, time_comp))
+            
+            # Decompression
+            b_decomp = @benchmark Array{Float64}($compressed)
+            time_decomp = mean(b_decomp.times) / 1e6  # Convert ns to ms and compute mean
+
+            results[with_extrema][type_name]["decompression"] = Int(calculate_throughput(size_mb, time_decomp))
+        end
+    end
+
+    results
+end
+
+"""
+Benchmark log quantization for a given array size
+"""
+function benchmark_log_quantization(n::Int)
+    A = rand(Float64, n)
+    size_mb = sizeof(A)/1000^2
+    
+    println("\nBenchmarking Log Quantization (Array size: $(size_mb) MB)...")
+    
+    # Store results
+    results = Dict{String, Dict{String, Dict{String, Int}}}()
+    
+    for method in [:linspace, :logspace]
+        results[string(method)] = Dict{String, Dict{String, Int}}()
+        
+        for Q in [LogQuant8Array, LogQuant16Array, LogQuant24Array, LogQuant32Array]
+            type_name = string(Q)
+            results[string(method)][type_name] = Dict{String, Int}()
+            
+            # Compression
+            b_comp = @benchmark $Q($A, $method)
+            time_comp = mean(b_comp.times) / 1e6  # Convert ns to ms and compute mean
+            speed_comp = calculate_throughput(size_mb, time_comp)
+            results[string(method)][type_name]["compression"] = Int(speed_comp)
+            
+            # Create a compressed array for decompression benchmark
+            compressed = Q(A, method)
+            
+            # Decompression
+            b_decomp = @benchmark Array{Float64}($compressed)
+            time_decomp = mean(b_decomp.times) / 1e6  # Convert ns to ms and compute mean
+            speed_decomp = calculate_throughput(size_mb, time_decomp)
+            results[string(method)][type_name]["decompression"] = Int(speed_decomp)
+        end
+    end
+    
+    results
+end
+
+"""
+Print markdown table for linear quantization results
+""" 
+function print_lin_results(results)
+    # Print markdown table with reordered types
+    println("\n| Method           | UInt8    | Int8     | UInt16    | Int16     | UInt24   | Int24    | UInt32   | Int32    |")
+    println("| ---------------- | -------: | -------: | --------: | --------: | -------: | -------: | -------: | -------: |")
+    
+    for with_extrema in ["default", "custom"]
+        println("| $(with_extrema == "default" ? "**Default extrema**" : "**Custom extrema**") |")
+        # Print compression results
+        print("| compression      |")
+        for type in ["UInt8", "Int8", "UInt16", "Int16", "UInt24", "Int24", "UInt32", "Int32"]
+
+            @printf(" %4d MB/s |", results[with_extrema][type]["compression"])
+        end
+        println()
+    
+        # Print decompression results
+        print("| decompression    |")
+        for type in ["UInt8", "Int8", "UInt16", "Int16", "UInt24", "Int24", "UInt32", "Int32"]
+            @printf(" %4d MB/s |", results[with_extrema][type]["decompression"])
+        end
+        println()
+    end
+    println("\n")
+end
+
+"""
+Print markdown table for logarithmic quantization results
+"""
+function print_log_results(results)
+    # Print markdown table
+    println("\n| Method           | UInt8    | UInt16    | UInt24   | UInt32   |")
+    println("| ---------------- | -------: | --------: | -------: | -------: |")
+    
+    for method in ["linspace", "logspace"]
+        println("| **$(method)** |")
+        # Print compression results
+        print("| compression      |")
+        for type in ["LogQuant8Array", "LogQuant16Array", "LogQuant24Array", "LogQuant32Array"]
+            @printf(" %4d MB/s |", results[method][type]["compression"])
+        end
+        println()
+        
+        # Print decompression results
+        print("| decompression    |")
+        for type in ["LogQuant8Array", "LogQuant16Array", "LogQuant24Array", "LogQuant32Array"]
+            @printf(" %4d MB/s |", results[method][type]["decompression"])
+        end
+        println()
+    end
+    println()
+end
+
+
+# Example usage:
+#results_linear = benchmark_linear_quantization(10_000_000) 
+#print_lin_results(results_linear)   
+
+results_log = benchmark_log_quantization(10_000_000);
+print_log_results(results_log)

--- a/test/benchmarking.jl
+++ b/test/benchmarking.jl
@@ -157,5 +157,5 @@ end
 #results_linear = benchmark_linear_quantization(10_000_000) 
 #print_lin_results(results_linear)   
 
-results_log = benchmark_log_quantization(10_000_000);
-print_log_results(results_log)
+#results_log = benchmark_log_quantization(10_000_000);
+#print_log_results(results_log)

--- a/test/benchmarking.jl
+++ b/test/benchmarking.jl
@@ -15,6 +15,22 @@ function calculate_throughput(size_mb::Float64, time_ms::Float64)
 end
 
 """
+Benchmark the overhead of calling `Base.extrema`
+"""
+function benchmark_extrema_overhead()
+    results = Dict{String, Dict{String, Float64}}()
+    for n in [10^4, 10^5, 10^6, 10^7]
+        results[string(n)] = Dict{String, Float64}()
+        for T in [Float64, Float32, Float16]
+            A = rand(T, n)
+            b_comp = @benchmark Base.extrema($A)
+            results[string(n)][string(T)] = mean(b_comp.times) / 1e6
+        end
+    end
+    return results
+end
+
+"""
 Benchmark linear quantization for a given array size
 """
 function benchmark_linear_quantization(n::Int)
@@ -98,6 +114,17 @@ function benchmark_log_quantization(n::Int)
 end
 
 """
+Print markdown table for extrema overhead results
+"""
+function print_extrema_overhead(results)
+    println("\n| Array size | Float64 | Float32 | Float16 |")
+    println("| ------------ | --------: | --------: | --------: |")
+    for n in [10^4, 10^5, 10^6, 10^7]
+        @printf("| 10^%d | %f ms | %f ms | %f ms |\n", Int(log10(n)), results[string(n)]["Float64"], results[string(n)]["Float32"], results[string(n)]["Float16"])
+    end
+end
+
+"""
 Print markdown table for linear quantization results
 """ 
 function print_lin_results(results)
@@ -159,3 +186,6 @@ end
 
 #results_log = benchmark_log_quantization(10_000_000);
 #print_log_results(results_log)
+
+results_extrema = benchmark_extrema_overhead()
+print_extrema_overhead(results_extrema)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,27 +1,6 @@
 using LinLogQuantization
-using Infiltrator
 using Test
 
-
-T = Float16
-U = Int16 
-
-A = rand(T, (10,10))
-Amin, Amax = extrema(A)
-Q = LinQuantization(U,A)
-A2 = Array{T}(Q)
-
-Qmin = Q.min                     # min of original Array as Float64
-Qmax = Q.max                     # max of original Array as Float64
-Tmin = Float64(typemin(eltype(Q)))  # min representable in type as Float64
-Tmax = Float64(typemax(eltype(Q)))  # max representable in type as Float64
-Δ = (Qmax-Qmin)/(Tmax-Tmin) 
-Δ⁻¹ = Amin == Amax ? zero(Float64) : (Tmax-Tmin)/(Amax-Amin)
-1 / Δ⁻¹
-
-A[1]
-Q1 = round((A[1]-Amin)*Δ⁻¹ + Tmin)
-Qmin + (Q1-Tmin)*Δ
 
 @testset "minpos" begin
     @test minpos([0,0,0,0]) == 0
@@ -63,6 +42,39 @@ end
 
                     # then test whether back&forth conversion is reversible
                     @test A2 == Array{T}(LinQuantArray{U}(A2))
+                end
+            end
+        end
+    end
+
+    @testset "Custom extrema" begin 
+        for ext in [(-0.8, 0.6), (-0.6, 0.75), (-0.5, 0.5)]
+            for T in [Float64, Float32, Float16]
+                for s in [(100,),
+                            (10,20),
+                            (13,14,15),
+                            (23,17,12,5)]
+                
+                    A = rand(T,s...)
+
+                    for U in [
+                                UInt8,
+                                UInt16,
+                                UInt24,
+                                UInt32,
+                                Int8,
+                                Int16,
+                                Int24,
+                                Int32
+                            ]  
+                        
+                        # initial conversion is not reversible
+                        # due to rounding errors
+                        A2 = Array{T}(LinQuantArray{U}(A; extrema=ext))
+
+                        # then test whether back&forth conversion is reversible
+                        @test A2 == Array{T}(LinQuantArray{U}(A2; extrema=ext))
+                    end
                 end
             end
         end
@@ -110,6 +122,19 @@ end
 
     Q = LinQuant8Array(A,4)
     @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
+
+    A = rand(Float32,10,20,30,40)
+    Q = LinQuantArray{Int32}(A,4)
+    @test A ≈ Array{Float32}(Q)
+
+    Q = LinQuantArray{Int24}(A,4)
+    @test A ≈ Array{Float32}(Q)
+
+    Q = LinQuantArray{Int16}(A,4)
+    @test A ≈ Array{Float32}(Q)
+
+    Q = LinQuantArray{Int8}(A,4)
+    @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
 end
 
 @testset "LogQuant along dimension" begin
@@ -136,17 +161,23 @@ end
         
             A = zeros(T,s...)
 
-            for LinQ in [LinQuant8Array,
-                        LinQuant16Array,
-                        LinQuant24Array,
-                        LinQuant32Array]
-                
+            for U in [
+                        UInt8,
+                        UInt16,
+                        UInt24,
+                        UInt32,
+                        Int8,
+                        Int16,
+                        Int24,
+                        Int32
+                    ]  
+                        
                 # initial conversion is not reversible
                 # due to rounding errors
-                A2 = Array{T}(LinQ(A))
+                A2 = Array{T}(LinQuantArray{U}(A))
 
                 # then test whether back&forth conversion is reversible
-                @test A2 == Array{T}(LinQ(A2))
+                @test A2 == Array{T}(LinQuantArray{U}(A2))
             end
         end
     end
@@ -186,17 +217,23 @@ end
         
             A = zeros(T,s...) .+ T(randn())
 
-            for LinQ in [LinQuant8Array,
-                        LinQuant16Array,
-                        LinQuant24Array,
-                        LinQuant32Array]
+            for U in [
+                        UInt8,
+                        UInt16,
+                        UInt24,
+                        UInt32,
+                        Int8,
+                        Int16,
+                        Int24,
+                        Int32
+                    ]  
                 
                 # initial conversion is not reversible
                 # due to rounding errors
-                A2 = Array{T}(LinQ(A))
+                A2 = Array{T}(LinQuantArray{U}(A))
 
                 # then test whether back&forth conversion is reversible
-                @test A2 == Array{T}(LinQ(A2))
+                @test A2 == Array{T}(LinQuantArray{U}(A2))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,7 +211,6 @@ end
             A2 = Array{Float32}(LinQuantArray{UInt32}(A, 4; extrema=ext))
             @test A2 == Array{Float32}(LinQuantArray{UInt32}(A2, 4; extrema=ext))
 
-
             A2 = Array{Float32}(LinQuantArray{UInt24}(A, 4; extrema=ext))
             @test A2 == Array{Float32}(LinQuantArray{UInt24}(A2, 4; extrema=ext))
             
@@ -258,14 +257,15 @@ end
 @testset "LogQuant along dimension" begin
     A = rand(Float32,10,20,30,40)
 
-    for T in (Int32, Int24, Int16, Int8)
+    for T in (UInt32, UInt24, UInt16)
         Q = LogQuantArray{T}(A, 4)
         A2 = Array{Float32}(Q)
         @test A ≈ Array{Float32}(Q)
         @test A2 == Array{Float32}(LogQuantArray{T}(A2, 4))
     end
 
-    Q = LogQuant8Array(A,4)
+    # higher tolerance for UInt8
+    Q = LogQuantArray{UInt8}(A,4)
     @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,7 @@ end
                     (23,17,12,5)]
         
             # Generate a matrix with values between -1 and 1
-            A = 2 * rand(T, s...) .- 1
+            A = rand(T, s...)
 
             for LogQ in [LogQuant8Array,
                         LogQuant16Array,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,8 @@ end
                         (13,14,15),
                         (23,17,12,5)]
             
-                A = rand(T,s...)
+                # Generate a matrix with values between -1 and 1
+                A = rand(T, s...)
 
                 for U in [
                             UInt8,
@@ -55,7 +56,8 @@ end
                             (13,14,15),
                             (23,17,12,5)]
                 
-                    A = rand(T,s...)
+                    # Generate a matrix with values between -1 and 1
+                    A = rand(T, s...)
 
                     for U in [
                                 UInt8,
@@ -74,7 +76,41 @@ end
 
                         # then test whether back&forth conversion is reversible
                         @test A2 == Array{T}(LinQuantArray{U}(A2; extrema=ext))
-                        @test Base.extrema(A2) == ext
+                        @test Base.extrema(A2) == T.(ext)
+                    end
+                end
+            end
+        end
+    end
+
+    @testset "Matrix with negative values and custom extrema" begin
+        for ext in [(-0.1, 0.6), (-0.22, 0.35), (-0.3, 0.45)]
+            for T in [Float64, Float32, Float16]
+                for s in [(100,),
+                            (10,20),
+                            (13,14,15),
+                            (23,17,12,5)]
+                
+                    # Generate a matrix with values between -1 and 1
+                    A = 2 * rand(T, s...) .- 1
+
+                    @test minimum(A) < 0
+                    @test maximum(A) > 0
+
+                    for U in [
+                                Int8,
+                                Int16,
+                                Int24,
+                                Int32
+                            ]  
+                        
+                        # initial conversion is not reversible
+                        # due to rounding errors
+                        A2 = Array{T}(LinQuantArray{U}(A; extrema=ext))
+
+                        # then test whether back&forth conversion is reversible
+                        @test A2 == Array{T}(LinQuantArray{U}(A2; extrema=ext))
+                        @test Base.extrema(A2) == T.(ext)
                     end
                 end
             end
@@ -89,7 +125,8 @@ end
                     (13,14,15),
                     (23,17,12,5)]
         
-            A = rand(T,s...)
+            # Generate a matrix with values between -1 and 1
+            A = 2 * rand(T, s...) .- 1
 
             for LogQ in [LogQuant8Array,
                         LogQuant16Array,
@@ -140,8 +177,54 @@ end
     end 
 
     @testset "Custom extrema" begin
+        for ext in [(0.1, 0.6), (0.22, 0.75), (0.3, 0.5)]
+            A = rand(Float32,10,20,30,40)
+
+            A2 = Array{Float32}(LinQuantArray{UInt32}(A, 4; extrema=ext))
+            @test A2 == Array{Float32}(LinQuantArray{UInt32}(A2, 4; extrema=ext))
 
 
+            A2 = Array{Float32}(LinQuantArray{UInt24}(A, 4; extrema=ext))
+            @test A2 == Array{Float32}(LinQuantArray{UInt24}(A2, 4; extrema=ext))
+            
+            A2 = Array{Float32}(LinQuantArray{UInt16}(A, 4; extrema=ext))
+            @test A2 == Array{Float32}(LinQuantArray{UInt16}(A2, 4; extrema=ext))
+
+            A2 = Array{Float32}(LinQuantArray{UInt8}(A, 4; extrema=ext))
+            all(isapprox.(A2, Array{Float32}(LinQuantArray{UInt8}(A2, 4; extrema=ext)), atol=1e-1))
+
+            A2 = Array{Float32}(LinQuantArray{Int32}(A, 4; extrema=ext))
+            @test A2 == Array{Float32}(LinQuantArray{Int32}(A2, 4; extrema=ext))
+
+            A2 = Array{Float32}(LinQuantArray{Int24}(A, 4; extrema=ext))
+            @test A2 == Array{Float32}(LinQuantArray{Int24}(A2, 4; extrema=ext))
+            
+            A2 = Array{Float32}(LinQuantArray{Int16}(A, 4; extrema=ext))
+            @test A2 == Array{Float32}(LinQuantArray{Int16}(A2, 4; extrema=ext))
+
+            A2 = Array{Float32}(LinQuantArray{Int8}(A, 4; extrema=ext))
+            all(isapprox.(A2, Array{Float32}(LinQuantArray{Int8}(A2, 4; extrema=ext)), atol=1e-1))
+
+        end
+    end
+
+    @testset "Negative values" begin
+
+        A = 2 * rand(Float32,10,20,30,40) .- 1
+        @test minimum(A) < 0
+        @test maximum(A) > 0
+
+        Q = LinQuantArray{Int32}(A, 4)
+        @test A ≈ Array{Float32}(Q)
+
+        Q = LinQuantArray{Int24}(A, 4)
+        @test A ≈ Array{Float32}(Q)
+
+        Q = LinQuantArray{Int16}(A, 4)
+        @test A ≈ Array{Float32}(Q)
+
+        Q = LinQuantArray{Int8}(A, 4)
+        @test all(isapprox.(A, Array{Float32}(Q), atol=1e-1))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
                         (13,14,15),
                         (23,17,12,5)]
             
-                # Generate a matrix with values between -1 and 1
+                # Generate a matrix with values between 0 and 1
                 A = rand(T, s...)
 
                 for L in [
@@ -51,7 +51,7 @@ end
                         (13,14,15),
                         (23,17,12,5)]
             
-                # Generate a matrix with values between -1 and 1
+                # Generate a matrix with values between 0 and 1
                 A = rand(T, s...)
 
                 for U in [
@@ -84,7 +84,7 @@ end
                             (13,14,15),
                             (23,17,12,5)]
                 
-                    # Generate a matrix with values between -1 and 1
+                    # Generate a matrix with values between 0 and 1
                     A = rand(T, s...)
 
                     for U in [
@@ -165,10 +165,10 @@ end
                 
                     # initial conversion is not reversible
                     # due to rounding errors
-                    A2 = Array{T}(LogQ(A,rn))
+                    A2 = Array{T}(LogQ(A, rn))
 
                     # then test whether back&forth conversion is reversible
-                    @test A2 == Array{T}(LogQ(A2,rn))
+                    @test A2 == Array{T}(LogQ(A2, rn))
                 end
             end
         end
@@ -242,14 +242,12 @@ end
         @test minimum(A) < 0
         @test maximum(A) > 0
 
-        Q = LinQuantArray{Int32}(A, 4)
-        @test A ≈ Array{Float32}(Q)
-
-        Q = LinQuantArray{Int24}(A, 4)
-        @test A ≈ Array{Float32}(Q)
-
-        Q = LinQuantArray{Int16}(A, 4)
-        @test A ≈ Array{Float32}(Q)
+        for T in (Int32, Int24, Int16, Int8)
+            Q = LinQuantArray{T}(A, 4)
+            A2 = Array{Float32}(Q)
+            @test A ≈ Array{Float32}(Q)
+            @test A2 == Array{Float32}(LinQuantArray{T}(A2, 4))
+        end
 
         Q = LinQuantArray{Int8}(A, 4)
         @test all(isapprox.(A, Array{Float32}(Q), atol=1e-1))
@@ -258,14 +256,13 @@ end
 
 @testset "LogQuant along dimension" begin
     A = rand(Float32,10,20,30,40)
-    Q = LogQuant32Array(A,4)
-    @test A ≈ Array{Float32}(Q)
 
-    Q = LogQuant24Array(A,4)
-    @test A ≈ Array{Float32}(Q)
-
-    Q = LogQuant16Array(A,4)
-    @test A ≈ Array{Float32}(Q)
+    for T in (Int32, Int24, Int16, Int8)
+        Q = LogQuantArray{T}(A, 4)
+        A2 = Array{Float32}(Q)
+        @test A ≈ Array{Float32}(Q)
+        @test A2 == Array{Float32}(LogQuantArray{T}(A2, 4))
+    end
 
     Q = LogQuant8Array(A,4)
     @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,13 +242,14 @@ end
         @test minimum(A) < 0
         @test maximum(A) > 0
 
-        for T in (Int32, Int24, Int16, Int8)
+        for T in (Int32, Int24, Int16)
             Q = LinQuantArray{T}(A, 4)
             A2 = Array{Float32}(Q)
             @test A ≈ Array{Float32}(Q)
             @test A2 == Array{Float32}(LinQuantArray{T}(A2, 4))
         end
 
+        # higher tolerance for Int8
         Q = LinQuantArray{Int8}(A, 4)
         @test all(isapprox.(A, Array{Float32}(Q), atol=1e-1))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,34 @@ end
 
 @testset "Linear quantization" begin
 
+    @testset "Backward compatibility" begin 
+        for T in [Float64, Float32, Float16]
+            for s in [(100,),
+                        (10,20),
+                        (13,14,15),
+                        (23,17,12,5)]
+            
+                # Generate a matrix with values between -1 and 1
+                A = rand(T, s...)
+
+                for L in [
+                            LinQuant8Array,
+                            LinQuant16Array,
+                            LinQuant24Array,
+                            LinQuant32Array
+                        ]  
+                    
+                    # initial conversion is not reversible
+                    # due to rounding errors
+                    A2 = Array{T}(L(A))
+
+                    # then test whether back&forth conversion is reversible
+                    @test A2 == Array{T}(L(A2))
+                end
+            end
+        end
+    end 
+
     @testset "Default extrema" begin 
         for T in [Float64, Float32, Float16]
             for s in [(100,),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ end
     end
 
     @testset "Custom extrema" begin 
-        for ext in [(-0.8, 0.6), (-0.6, 0.75), (-0.5, 0.5)]
+        for ext in [(0.1, 0.6), (0.22, 0.75), (0.3, 0.5)]
             for T in [Float64, Float32, Float16]
                 for s in [(100,),
                             (10,20),
@@ -74,6 +74,7 @@ end
 
                         # then test whether back&forth conversion is reversible
                         @test A2 == Array{T}(LinQuantArray{U}(A2; extrema=ext))
+                        @test Base.extrema(A2) == ext
                     end
                 end
             end
@@ -110,31 +111,38 @@ end
 end
 
 @testset "LinQuant along dimension" begin
-    A = rand(Float32,10,20,30,40)
-    Q = LinQuant32Array(A,4)
-    @test A ≈ Array{Float32}(Q)
+    @testset "Default extrema" begin
+        A = rand(Float32,10,20,30,40)
+        Q = LinQuant32Array(A,4)
+        @test A ≈ Array{Float32}(Q)
 
-    Q = LinQuant24Array(A,4)
-    @test A ≈ Array{Float32}(Q)
+        Q = LinQuant24Array(A,4)
+        @test A ≈ Array{Float32}(Q)
 
-    Q = LinQuant16Array(A,4)
-    @test A ≈ Array{Float32}(Q)
+        Q = LinQuant16Array(A,4)
+        @test A ≈ Array{Float32}(Q)
 
-    Q = LinQuant8Array(A,4)
-    @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
+        Q = LinQuant8Array(A,4)
+        @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
 
-    A = rand(Float32,10,20,30,40)
-    Q = LinQuantArray{Int32}(A,4)
-    @test A ≈ Array{Float32}(Q)
+        A = rand(Float32,10,20,30,40)
+        Q = LinQuantArray{Int32}(A,4)
+        @test A ≈ Array{Float32}(Q)
 
-    Q = LinQuantArray{Int24}(A,4)
-    @test A ≈ Array{Float32}(Q)
+        Q = LinQuantArray{Int24}(A,4)
+        @test A ≈ Array{Float32}(Q)
 
-    Q = LinQuantArray{Int16}(A,4)
-    @test A ≈ Array{Float32}(Q)
+        Q = LinQuantArray{Int16}(A,4)
+        @test A ≈ Array{Float32}(Q)
 
-    Q = LinQuantArray{Int8}(A,4)
-    @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
+        Q = LinQuantArray{Int8}(A,4)
+        @test all(isapprox.(A,Array{Float32}(Q),atol=1e-1))
+    end 
+
+    @testset "Custom extrema" begin
+
+
+    end
 end
 
 @testset "LogQuant along dimension" begin


### PR DESCRIPTION
@milankl 
I have the basic implementation:
```julia 
# minimum and maximum representable value of type T
Tmin, Tmax = Float64(typemin(T)), Float64(typemax(T))

# LinQuantization
Δ⁻¹ =  (Tmax-Tmin)/(Amax-Amin) # (Tmax -  Tmin) == (2^sizeof(T)-1), but  imo Tmax - Tmin is more informative and the values are used afterwards again anyways

Q[i] = round(T, clamp((A[i]-Amin)*Δ⁻¹ + Tmin, Tmin, Tmax)) 
...

# Base.Array
Δ = (Qmax-Qmin)/(Tmax-Tmin)
A[i] = Qmin + (Q[i] - Tmin)*Δ
```

And I have two questions: 

1. Could I remove the `n::Integer` argument from `Base.Array` ? In the end, the range of values can be calculated  as `typemax(eltype(Q)) - typemin(eltype(Q))` instead of `2^n - 1`.
2. Does it make sense to create aliases for `LinQuantization` and `LinQuantArray`, since the alias is equally long as the original call? e.g. 
```julia 
LinQuantInt8Array(A::AbstractArray{T,N},dim::Int,e::Option{Tuple}) where {T,N} = LinQuantArray(Int8,A,dim,e)
``` 

Also  I am facing some issues. The back and forth conversion with  signed integers is not equal for some values, with a different of 1.0 or 2.0. For `Float16` and `Int16` some values of A2 end up being `-∞` or `∞`. I don't exactly know what the problem is.
```julia
for T in [Float64, Float32, Float16]
   for s in [(100,), (10,20), (13,14,15), (23,17,12,5)]:
        A = rand(T,s...)

        for U in [Int8, Int16,  Int32]
            A2 = Array{T}(LinQuantization(U,A))
            B = Array{T}(LinQuantization(U,A2))

            if A2 != B 
                println("T = ", T, " U = ", U)
            end 
            for i in eachindex(A2)
                if A2[i] != B[i]
                    println(" A2[i] = ", A2[i], " B[i] = ", B[i])
                end
            end
        end
    end
end

# T = Float32 U = Int32
#  A2[i] = 2.0507566e7 B[i] = 2.0507564e7
# T = Float32 U = Int32
#  A2[i] = 8.266649e6 B[i] = 8.266648e6
# T = Float32 U = Int32
#  A2[i] = 6.41308e6 B[i] = 6.413079e6
#  A2[i] = 848596.0 B[i] = 848595.0
#  A2[i] = 3.2166338e7 B[i] = 3.2166336e7
#  A2[i] = 1.717558e6 B[i] = 1.717557e6
#  A2[i] = 1.5504138e7 B[i] = 1.5504137e7
#  A2[i] = 3.065833e6 B[i] = 3.065832e6
#  A2[i] = 6.550137e6 B[i] = 6.550136e6
#  A2[i] = 9.974494e6 B[i] = 9.974493e6
# T = Float32 U = Int32
#  A2[i] = 1.3689715e7 B[i] = 1.3689714e7
#  A2[i] = 7.192029e6 B[i] = 7.192028e6
#  A2[i] = 8.769405e6 B[i] = 8.769404e6
#  A2[i] = 6.903743e6 B[i] = 6.903742e6
#  A2[i] = 2.544131e6 B[i] = 2.54413e6
#  A2[i] = 1.0867795e7 B[i] = 1.0867794e7
# ...
```